### PR TITLE
i18n wikivoyage.org: for german content should query de.wikivoyage.or…

### DIFF
--- a/index.php
+++ b/index.php
@@ -99,7 +99,7 @@ See documentation on http://api.wikijourney.eu/documentation.php
             if ($displayImg == 1) {
                 // We add description and image
 
-                $wikivoyageRequest = 'https://en.wikivoyage.org/w/api.php?action=query&format=json&' // Base
+                $wikivoyageRequest = 'https://'.$language.'.wikivoyage.org/w/api.php?action=query&format=json&' // Base
 .'prop=coordinates|info|pageterms|pageimages|langlinks&' // Props list
 .'piprop=thumbnail&pithumbsize=144&pilimit=50&inprop=url&wbptterms=description' // Properties dedicated to image, url and description
 .'&llprop=url' // Properties dedicated to langlinks
@@ -107,7 +107,7 @@ See documentation on http://api.wikijourney.eu/documentation.php
             } else {
                 // Simplified request
 
-                $wikivoyageRequest = 'https://en.wikivoyage.org/w/api.php?action=query&format=json&' // Base
+                $wikivoyageRequest = 'https://'.$language.'.wikivoyage.org/w/api.php?action=query&format=json&' // Base
 .'prop=coordinates|info|langlinks&' // Props list
 .'inprop=url' // Properties dedicated to url
 .'&llprop=url' // Properties dedicated to langlinks


### PR DESCRIPTION
…g instead of en.wikivoyage.org.

symptom: if i query the android app in german language for "puerto de mogan" i get "nothing found".

reason en.wikivoyage.org has no article for "puerto de mogan" while de.wikivoyage.org has.

Note: i have no php knowledge and i have no means to check my changes. i did the changes analog to reading from en.wikipedia.org. i verified that the urls 'en.wikivoyage.org', 
'fr.wikivoyage.org', 
'zh.wikivoyage.org',
'de.wikivoyage.org',
'es.wikivoyage.org'
exist
